### PR TITLE
make the logo go to the index

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -6,7 +6,7 @@ layout: default
 				<div class="container">
 
 					<!-- Logo -->
-						<h1><a href="#" id="logo">Food&Code</a></h1>
+						<h1><a href="/" id="logo">Food&Code</a></h1>
 
 					{% include nav.html %}
 


### PR DESCRIPTION
Right now it goes to `#`, which is not the norm, usually a header goes to the homepage.
